### PR TITLE
feat: add theme query param to customise survey rendering

### DIFF
--- a/apps/web/app/s/[surveyId]/components/LinkSurvey.tsx
+++ b/apps/web/app/s/[surveyId]/components/LinkSurvey.tsx
@@ -23,6 +23,7 @@ let setQuestionId = (_: string) => {};
 interface LinkSurveyProps {
   survey: TSurvey;
   product: TProduct;
+  theme?: string;
   userId?: string;
   emailVerificationStatus?: string;
   singleUseId?: string;
@@ -40,6 +41,7 @@ interface LinkSurveyProps {
 }
 
 export const LinkSurvey = ({
+  theme,
   survey,
   product,
   userId,
@@ -223,7 +225,8 @@ export const LinkSurvey = ({
       webAppUrl={webAppUrl}
       IS_FORMBRICKS_CLOUD={IS_FORMBRICKS_CLOUD}
       IMPRINT_URL={IMPRINT_URL}
-      PRIVACY_URL={PRIVACY_URL}>
+      PRIVACY_URL={PRIVACY_URL}
+      theme={theme}>
       <SurveyInline
         survey={survey}
         styling={determineStyling()}
@@ -300,6 +303,7 @@ export const LinkSurvey = ({
         startAtQuestionId={startAt && isStartAtValid ? startAt : undefined}
         fullSizeCards={isEmbed ? true : false}
         initialResponseData={hiddenFieldsRecord}
+        theme={theme}
       />
     </LinkSurveyWrapper>
   );

--- a/apps/web/app/s/[surveyId]/components/LinkSurvey.tsx
+++ b/apps/web/app/s/[surveyId]/components/LinkSurvey.tsx
@@ -23,7 +23,7 @@ let setQuestionId = (_: string) => {};
 interface LinkSurveyProps {
   survey: TSurvey;
   product: TProduct;
-  alignForm: string | undefined;
+  alignForm?: 'top';
   omitCardBorder: boolean;
   omitCardShadow: boolean;
   userId?: string;

--- a/apps/web/app/s/[surveyId]/components/LinkSurvey.tsx
+++ b/apps/web/app/s/[surveyId]/components/LinkSurvey.tsx
@@ -23,7 +23,9 @@ let setQuestionId = (_: string) => {};
 interface LinkSurveyProps {
   survey: TSurvey;
   product: TProduct;
-  theme?: string;
+  alignForm: string | undefined;
+  omitCardBorder: boolean;
+  omitCardShadow: boolean;
   userId?: string;
   emailVerificationStatus?: string;
   singleUseId?: string;
@@ -41,7 +43,9 @@ interface LinkSurveyProps {
 }
 
 export const LinkSurvey = ({
-  theme,
+  alignForm,
+  omitCardBorder,
+  omitCardShadow,
   survey,
   product,
   userId,
@@ -226,7 +230,7 @@ export const LinkSurvey = ({
       IS_FORMBRICKS_CLOUD={IS_FORMBRICKS_CLOUD}
       IMPRINT_URL={IMPRINT_URL}
       PRIVACY_URL={PRIVACY_URL}
-      theme={theme}>
+      alignForm={alignForm}>
       <SurveyInline
         survey={survey}
         styling={determineStyling()}
@@ -303,7 +307,8 @@ export const LinkSurvey = ({
         startAtQuestionId={startAt && isStartAtValid ? startAt : undefined}
         fullSizeCards={isEmbed ? true : false}
         initialResponseData={hiddenFieldsRecord}
-        theme={theme}
+        omitCardBorder={omitCardBorder}
+        omitCardShadow={omitCardShadow}
       />
     </LinkSurveyWrapper>
   );

--- a/apps/web/app/s/[surveyId]/components/LinkSurveyWrapper.tsx
+++ b/apps/web/app/s/[surveyId]/components/LinkSurveyWrapper.tsx
@@ -19,7 +19,7 @@ interface LinkSurveyWrapperProps {
   PRIVACY_URL?: string;
   IS_FORMBRICKS_CLOUD: boolean;
   webAppUrl: string;
-  theme?: string;
+  alignForm: string | undefined;
 }
 
 export const LinkSurveyWrapper = ({
@@ -34,7 +34,7 @@ export const LinkSurveyWrapper = ({
   PRIVACY_URL,
   IS_FORMBRICKS_CLOUD,
   webAppUrl,
-  theme,
+  alignForm,
 }: LinkSurveyWrapperProps) => {
   //for embedded survey strip away all surrounding css
   const styling = determineStyling();
@@ -55,7 +55,7 @@ export const LinkSurveyWrapper = ({
         <MediaBackground survey={survey} product={product}>
           <div
             className={cn(
-              theme === "welbee" ? "items-start" : "items-end md:items-center",
+              alignForm === "top" ? "items-start" : "items-end md:items-center",
               "flex max-h-dvh min-h-dvh justify-center overflow-clip"
             )}>
             {!styling.isLogoHidden && product.logo?.url && <ClientLogo product={product} />}

--- a/apps/web/app/s/[surveyId]/components/LinkSurveyWrapper.tsx
+++ b/apps/web/app/s/[surveyId]/components/LinkSurveyWrapper.tsx
@@ -19,6 +19,7 @@ interface LinkSurveyWrapperProps {
   PRIVACY_URL?: string;
   IS_FORMBRICKS_CLOUD: boolean;
   webAppUrl: string;
+  theme?: string;
 }
 
 export const LinkSurveyWrapper = ({
@@ -33,6 +34,7 @@ export const LinkSurveyWrapper = ({
   PRIVACY_URL,
   IS_FORMBRICKS_CLOUD,
   webAppUrl,
+  theme,
 }: LinkSurveyWrapperProps) => {
   //for embedded survey strip away all surrounding css
   const styling = determineStyling();
@@ -51,7 +53,11 @@ export const LinkSurveyWrapper = ({
     return (
       <div>
         <MediaBackground survey={survey} product={product}>
-          <div className="flex max-h-dvh min-h-dvh items-end justify-center overflow-clip md:items-center">
+          <div
+            className={cn(
+              theme === "welbee" ? "items-start" : "items-end md:items-center",
+              "flex max-h-dvh min-h-dvh justify-center overflow-clip"
+            )}>
             {!styling.isLogoHidden && product.logo?.url && <ClientLogo product={product} />}
             <div className="h-full w-full space-y-6 p-0 md:max-w-md">
               {isPreview && (

--- a/apps/web/app/s/[surveyId]/components/LinkSurveyWrapper.tsx
+++ b/apps/web/app/s/[surveyId]/components/LinkSurveyWrapper.tsx
@@ -19,7 +19,7 @@ interface LinkSurveyWrapperProps {
   PRIVACY_URL?: string;
   IS_FORMBRICKS_CLOUD: boolean;
   webAppUrl: string;
-  alignForm: string | undefined;
+  alignForm?: 'top' ;
 }
 
 export const LinkSurveyWrapper = ({

--- a/apps/web/app/s/[surveyId]/page.tsx
+++ b/apps/web/app/s/[surveyId]/page.tsx
@@ -38,7 +38,9 @@ interface LinkSurveyPageProps {
     surveyId: string;
   };
   searchParams: {
-    theme?: string;
+    alignForm?: string;
+    omitCardBorder?: string;
+    omitCardShadow?: string;
     suId?: string;
     userId?: string;
     responseId?: string;
@@ -64,7 +66,10 @@ const Page = async ({ params, searchParams }: LinkSurveyPageProps) => {
   }
   const survey = await getSurvey(params.surveyId);
 
-  const theme = searchParams.theme;
+  const alignForm = searchParams.alignForm;
+  const omitCardBorder = searchParams.omitCardBorder === "true";
+  const omitCardShadow = searchParams.omitCardShadow === "true";
+
   const suId = searchParams.suId;
   const userId = searchParams.userId;
   const responseId = searchParams.responseId;
@@ -214,7 +219,9 @@ const Page = async ({ params, searchParams }: LinkSurveyPageProps) => {
       survey={survey}
       product={product}
       userId={userId}
-      theme={theme}
+      alignForm={alignForm}
+      omitCardBorder={omitCardBorder}
+      omitCardShadow={omitCardShadow}
       emailVerificationStatus={emailVerificationStatus}
       singleUseId={isSingleUseSurvey ? singleUseId : undefined}
       singleUseResponse={singleUseResponse ? singleUseResponse : undefined}

--- a/apps/web/app/s/[surveyId]/page.tsx
+++ b/apps/web/app/s/[surveyId]/page.tsx
@@ -38,6 +38,7 @@ interface LinkSurveyPageProps {
     surveyId: string;
   };
   searchParams: {
+    theme?: string;
     suId?: string;
     userId?: string;
     responseId?: string;
@@ -63,6 +64,7 @@ const Page = async ({ params, searchParams }: LinkSurveyPageProps) => {
   }
   const survey = await getSurvey(params.surveyId);
 
+  const theme = searchParams.theme;
   const suId = searchParams.suId;
   const userId = searchParams.userId;
   const responseId = searchParams.responseId;
@@ -212,6 +214,7 @@ const Page = async ({ params, searchParams }: LinkSurveyPageProps) => {
       survey={survey}
       product={product}
       userId={userId}
+      theme={theme}
       emailVerificationStatus={emailVerificationStatus}
       singleUseId={isSingleUseSurvey ? singleUseId : undefined}
       singleUseResponse={singleUseResponse ? singleUseResponse : undefined}

--- a/apps/web/app/s/[surveyId]/page.tsx
+++ b/apps/web/app/s/[surveyId]/page.tsx
@@ -38,7 +38,7 @@ interface LinkSurveyPageProps {
     surveyId: string;
   };
   searchParams: {
-    alignForm?: string;
+    alignForm?: 'top' ;
     omitCardBorder?: string;
     omitCardShadow?: string;
     suId?: string;

--- a/packages/surveys/src/components/general/Survey.tsx
+++ b/packages/surveys/src/components/general/Survey.tsx
@@ -38,7 +38,8 @@ export const Survey = ({
   shouldResetQuestionId,
   fullSizeCards = false,
   initialResponseData,
-  theme,
+  omitCardBorder,
+  omitCardShadow,
 }: SurveyBaseProps) => {
   const isInIframe = window.self !== window.top;
 
@@ -281,7 +282,7 @@ export const Survey = ({
         <div
           className={cn(
             "no-scrollbar md:rounded-custom rounded-t-custom bg-survey-bg flex h-full w-full flex-col justify-between overflow-hidden transition-all duration-1000 ease-in-out",
-            theme === "welbee" ? "" : cardArrangement === "simple" ? "fb-survey-shadow" : "",
+            omitCardShadow ? "" : cardArrangement === "simple" ? "fb-survey-shadow" : "",
             offset === 0 || cardArrangement === "simple" ? "opacity-100" : "opacity-0"
           )}>
           <div
@@ -308,7 +309,7 @@ export const Survey = ({
       setQuestionId={setQuestionId}
       shouldResetQuestionId={shouldResetQuestionId}
       fullSizeCards={fullSizeCards}
-      theme={theme}
+      omitCardBorder={!!omitCardBorder}
     />
   );
 };

--- a/packages/surveys/src/components/general/Survey.tsx
+++ b/packages/surveys/src/components/general/Survey.tsx
@@ -38,6 +38,7 @@ export const Survey = ({
   shouldResetQuestionId,
   fullSizeCards = false,
   initialResponseData,
+  theme,
 }: SurveyBaseProps) => {
   const isInIframe = window.self !== window.top;
 
@@ -280,7 +281,7 @@ export const Survey = ({
         <div
           className={cn(
             "no-scrollbar md:rounded-custom rounded-t-custom bg-survey-bg flex h-full w-full flex-col justify-between overflow-hidden transition-all duration-1000 ease-in-out",
-            cardArrangement === "simple" ? "fb-survey-shadow" : "",
+            theme === "welbee" ? "" : cardArrangement === "simple" ? "fb-survey-shadow" : "",
             offset === 0 || cardArrangement === "simple" ? "opacity-100" : "opacity-0"
           )}>
           <div
@@ -307,6 +308,7 @@ export const Survey = ({
       setQuestionId={setQuestionId}
       shouldResetQuestionId={shouldResetQuestionId}
       fullSizeCards={fullSizeCards}
+      theme={theme}
     />
   );
 };

--- a/packages/surveys/src/components/wrappers/StackedCardsContainer.tsx
+++ b/packages/surveys/src/components/wrappers/StackedCardsContainer.tsx
@@ -16,6 +16,7 @@ interface StackedCardsContainerProps {
   setQuestionId: (questionId: string) => void;
   shouldResetQuestionId?: boolean;
   fullSizeCards: boolean;
+  theme?: string;
 }
 
 export const StackedCardsContainer = ({
@@ -27,6 +28,7 @@ export const StackedCardsContainer = ({
   setQuestionId,
   shouldResetQuestionId = true,
   fullSizeCards = false,
+  theme,
 }: StackedCardsContainerProps) => {
   const [hovered, setHovered] = useState(false);
   const highlightBorderColor =
@@ -168,9 +170,13 @@ export const StackedCardsContainer = ({
       {cardArrangement === "simple" ? (
         <div
           className={cn("w-full", fullSizeCards ? "h-full" : "")}
-          style={{
-            ...borderStyles,
-          }}>
+          style={
+            theme === "welbee"
+              ? undefined
+              : {
+                  ...borderStyles,
+                }
+          }>
           {getCardContent(questionIdxTemp, 0)}
         </div>
       ) : (

--- a/packages/surveys/src/components/wrappers/StackedCardsContainer.tsx
+++ b/packages/surveys/src/components/wrappers/StackedCardsContainer.tsx
@@ -16,7 +16,7 @@ interface StackedCardsContainerProps {
   setQuestionId: (questionId: string) => void;
   shouldResetQuestionId?: boolean;
   fullSizeCards: boolean;
-  theme?: string;
+  omitCardBorder: boolean;
 }
 
 export const StackedCardsContainer = ({
@@ -28,7 +28,7 @@ export const StackedCardsContainer = ({
   setQuestionId,
   shouldResetQuestionId = true,
   fullSizeCards = false,
-  theme,
+  omitCardBorder,
 }: StackedCardsContainerProps) => {
   const [hovered, setHovered] = useState(false);
   const highlightBorderColor =
@@ -171,7 +171,7 @@ export const StackedCardsContainer = ({
         <div
           className={cn("w-full", fullSizeCards ? "h-full" : "")}
           style={
-            theme === "welbee"
+            omitCardBorder
               ? undefined
               : {
                   ...borderStyles,

--- a/packages/types/formbricksSurveys.ts
+++ b/packages/types/formbricksSurveys.ts
@@ -28,11 +28,12 @@ export interface SurveyBaseProps {
   shouldResetQuestionId?: boolean;
   fullSizeCards?: boolean;
   initialResponseData?: TResponseData;
+  omitCardBorder?: boolean;
+  omitCardShadow?: boolean;
 }
 
 export interface SurveyInlineProps extends SurveyBaseProps {
   containerId: string;
-  theme?: string;
 }
 
 export interface SurveyModalProps extends SurveyBaseProps {

--- a/packages/types/formbricksSurveys.ts
+++ b/packages/types/formbricksSurveys.ts
@@ -32,6 +32,7 @@ export interface SurveyBaseProps {
 
 export interface SurveyInlineProps extends SurveyBaseProps {
   containerId: string;
+  theme?: string;
 }
 
 export interface SurveyModalProps extends SurveyBaseProps {


### PR DESCRIPTION
Add new `theme` parameter to iframe's url.
When it is set to `welbee` it permits to customise the UI for welbee.