### PR TITLE
fix: show upload error inline

### DIFF
--- a/packages/api/src/api/client/storage.ts
+++ b/packages/api/src/api/client/storage.ts
@@ -85,7 +85,7 @@ export class StorageAPI {
       // if s3 is used, we'll use the text response:
       const errorText = await uploadResponse.text();
       if (presignedFields && errorText && errorText.includes("EntityTooLarge")) {
-        const error = new Error("File size exceeds the size limit for your plan");
+        const error = new Error("La dimensione del file supera il limite per il tuo piano");
         error.name = "FileTooLargeError";
         throw error;
       }

--- a/packages/surveys/src/components/general/FileInput.tsx
+++ b/packages/surveys/src/components/general/FileInput.tsx
@@ -7,6 +7,7 @@ import { TUploadFileConfig } from "@formbricks/types/storage";
 interface FileInputProps {
   allowedFileExtensions?: TAllowedFileExtension[];
   surveyId: string | undefined;
+  onError?: (e: string) => void;
   onUploadCallback: (uploadedUrls: string[]) => void;
   onFileUpload: (file: File, config?: TUploadFileConfig) => Promise<string>;
   fileUrls: string[] | undefined;
@@ -20,6 +21,7 @@ const FILE_LIMIT = 25;
 export const FileInput = ({
   allowedFileExtensions,
   surveyId,
+  onError = alert,
   onUploadCallback,
   onFileUpload,
   fileUrls,
@@ -35,7 +37,7 @@ export const FileInput = ({
       const fileBuffer = await file.arrayBuffer();
       const bufferKB = fileBuffer.byteLength / 1024;
       if (bufferKB > maxSizeInMB * 1024) {
-        alert(`File should be less than ${maxSizeInMB} MB`);
+        onError(`Il file non deve essere più grande di ${maxSizeInMB} MB`);
         return false;
       }
     }
@@ -62,7 +64,7 @@ export const FileInput = ({
       setSelectedFiles((prevFiles) => [...prevFiles, ...filteredFiles]);
       onUploadCallback(fileUrls ? [...fileUrls, ...uploadedUrls] : uploadedUrls);
     } catch (err: any) {
-      alert(err.name === "FileTooLargeError" ? err.message : "Upload failed! Please try again.");
+      onError(err.name === "FileTooLargeError" ? err.message : "Upload fallito! Riprova.");
     } finally {
       setIsUploading(false);
     }
@@ -72,12 +74,12 @@ export const FileInput = ({
     const fileArray = Array.from(files);
 
     if (!allowMultipleFiles && fileArray.length > 1) {
-      alert("Only one file can be uploaded at a time.");
+      onError("È possibile caricare un solo file alla volta.");
       return;
     }
 
     if (allowMultipleFiles && selectedFiles.length + fileArray.length > FILE_LIMIT) {
-      alert(`You can only upload a maximum of ${FILE_LIMIT} files.`);
+      onError(`Puoi caricare solo un massimo di ${FILE_LIMIT} file.`);
       return;
     }
 
@@ -92,7 +94,7 @@ export const FileInput = ({
     if (validFiles.length > 0) {
       handleFileUpload(validFiles);
     } else {
-      alert("No selected files are valid");
+      onError("Nessun file selezionato è valido");
     }
   };
 
@@ -215,7 +217,7 @@ export const FileInput = ({
                 />
               </svg>
               <p className="text-placeholder mt-2 text-sm dark:text-slate-400">
-                <span className="font-medium">Click or drag to upload files.</span>
+                <span className="font-medium">Clicca qui per selezionare il file da caricare.</span>
               </p>
               <input
                 type="file"

--- a/packages/surveys/src/components/questions/FileUploadQuestion.tsx
+++ b/packages/surveys/src/components/questions/FileUploadQuestion.tsx
@@ -47,10 +47,10 @@ export const FileUploadQuestion = ({
   const [startTime, setStartTime] = useState(performance.now());
   const isMediaAvailable = question.imageUrl || question.videoUrl;
   useTtc(question.id, ttc, setTtc, startTime, setStartTime, question.id === currentQuestionId);
-  const [hasError, setHasError] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     if (value && value.length > 0) {
-      setHasError(false);
+      setError(null);
     }
   }, [value]);
 
@@ -65,7 +65,7 @@ export const FileUploadQuestion = ({
           if (value && value.length > 0) {
             onSubmit({ [question.id]: value }, updatedTtcObj);
           } else {
-            setHasError(true);
+            setError("Selezionare un file per proseguire.");
           }
         } else {
           if (value) {
@@ -90,6 +90,7 @@ export const FileUploadQuestion = ({
           />
           <FileInput
             htmlFor={question.id}
+            onError={setError}
             surveyId={surveyId}
             onFileUpload={onFileUpload}
             onUploadCallback={(urls: string[]) => {
@@ -108,7 +109,7 @@ export const FileUploadQuestion = ({
           />
         </div>
       </ScrollableContainer>
-      {hasError && <div className="mt-1 px-5 text-sm text-red-500">Selezionare un file per proseguire.</div>}
+      {error && <div className="mt-1 px-5 text-sm text-red-500">{error}</div>}
       <div className="flex w-full justify-between px-6 py-4">
         {!isFirstQuestion && (
           <BackButton


### PR DESCRIPTION
Con questa PR modifichiamo il modo in cui vengono mostrati gli errori sul campo "File upload".
In precedenza veniva visualizzato un 'alert' con l'api del browser; adesso gli errori verranno mostrati all'interno del form stesso.